### PR TITLE
Add sd_product tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -6,6 +6,8 @@
 <html class="layout-root {{ language_flags_mode }} {{ language_names_mode }} {{ language_menu_mode }} {{ site_search_mode }}" lang="{{ page.language_code }}" data-view-state="{{ view_mode }}" data-lingual-mode="{{ site_lingual_mode }}" data-menu-main-state="closed">
   <head prefix="og: http://ogp.me/ns#">
     {% include "template-head" layout_product: true %}
+
+    {% sd_product %}
   </head>
 
   {% capture bottom_content_html %}


### PR DESCRIPTION
Include sd_product tag in Auto-rendered Product layout to render out product structured data.

Closes #242